### PR TITLE
Remove aliases in the author format

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,19 +23,30 @@ let g:github_co_author_list_path = '~/.vim/github-co-author-list'
 ### Local Config
 **Co Author Local Management File Path**
 
-`{git_work_space}/.git_author`  
+`{git_work_space}/.git_author`
+
 ![image](git_author_local_config_path.png)
 
 ### Co Author Management File Format
 ```
-alias1 name1 email1
-alias2 name2 email2
-alias3 name3 email3
+Alice <alice@example.com>
+Bob <bob@example.com>
+Charlie <charlie@example.com>
+```
+
+You can add authors from a github project using the output from `git shortlog -s -n -e` to the respective file:
+
+```shell
+# Local config
+git shortlog -s -n -e | cut -c8- > .git_author
+
+# Global config
+git shortlog -s -n -e | cut -c8- > ~/.vim/github-co-author-list
 ```
 
 ### Auto Complete Flow
 1. keymap
 1. hasLocal? return : next
 1. hasGlobal? return : next
-1. fallback return 
+1. fallback return
     > fallback message: `Co-Authored-By: name <email>`

--- a/plugin/plugin.vim
+++ b/plugin/plugin.vim
@@ -11,7 +11,7 @@ augroup END
 
 function! GetTeam()
   let records = ReadRecord()
-  
+
   let mem = []
 
   for record in records
@@ -19,9 +19,7 @@ function! GetTeam()
       continue
     endif
 
-    let cols = split(record)
-    let usernameAndEmail = cols[1] . ' ' . cols[2]
-    call add(mem, s:message_prefix . usernameAndEmail)
+    call add(mem, s:message_prefix . record)
   endfor
 
   call complete(col('.'), mem)
@@ -29,7 +27,6 @@ function! GetTeam()
 endfunction
 
 function! ReadRecord()
-  
   if HasLocal()
     return readfile(LocalPath())
   endif


### PR DESCRIPTION
Hello! I like the plugin that you have here and I made some changes to it 
locally which I thought might have interest upstream. 🙂 

---

We do not use the alias anywhere in the plugin so we should really
remove it.

There is more reason to remove it since we can use built-in functions of
git to generate the co-author list that makes it simple to list in the
complete menu and also appending to the co-author format.

We update the README in this change as well to reflect the changes and
also provide git examples that we can use to generate a list from a
project.